### PR TITLE
fix to onClientConnectionEncrypted() when data are on the socket befo…

### DIFF
--- a/src/mthreadserver.cpp
+++ b/src/mthreadserver.cpp
@@ -70,7 +70,8 @@ QMultiThreadedServer::onClientConnectionEncrypted()
     if (sslsock->bytesAvailable() > 0 )
     {
         MTSDBG << "Data already available in the socket during connection: "<< QString::number(sslsock->bytesAvailable()) << " bytes";
-        QTimer::singleShot(0, wo, SLOT(handleClientData()));
+        //QTimer::singleShot(0, wo, SLOT(handleClientData()));
+        sslsock->readyRead();
     }
 
 }


### PR DESCRIPTION
…re SSL handshake has been completed

as far as I understand in the case of HTTPS requests (non only an ssl connectin and THEN we start sending data)
the payload, hence data on the socket are available before the ssl handshake has been completed
We then enter the `if (sslsock->bytesAvailable() > 0 )` branch

Issue is that the `QTimer` call do not set the `sender()` to the `QTcpSocket*` object as expected from the worker
and as it correctly happen for not encrypted socket when the ready `readRead()` calls the `handleClientData()` from the connect
