### PR TITLE
fix "nullpt not defined" build error

### DIFF
--- a/src/ssl/nullptrCheck.h
+++ b/src/ssl/nullptrCheck.h
@@ -1,2 +1,4 @@
+#include  <QtGlobal>
 #define nullptr Q_NULLPTR
+
 

--- a/src/ssl/nullptrCheck.h
+++ b/src/ssl/nullptrCheck.h
@@ -1,17 +1,2 @@
-#if defined(__GNUC__)
-#  define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#  if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
-#    define GCC_CXX11
-#  endif
-#  if (GCC_VERSION < 40600) || !defined(GCC_CXX11)
-#    define NO_CXX11_NULLPTR
-#  endif
-#endif
-
-
-#if defined(NO_CXX11_NULLPTR)
-#pragma message("GCC does not support nullptr")
-#pragma message("Redefine nullptr as NULL")
-#define nullptr NULL
-#endif
+#define nullptr Q_NULLPTR
 

--- a/src/ssl/nullptrCheck.h
+++ b/src/ssl/nullptrCheck.h
@@ -1,0 +1,17 @@
+#if defined(__GNUC__)
+#  define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#  if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#    define GCC_CXX11
+#  endif
+#  if (GCC_VERSION < 40600) || !defined(GCC_CXX11)
+#    define NO_CXX11_NULLPTR
+#  endif
+#endif
+
+
+#if defined(NO_CXX11_NULLPTR)
+#pragma message("GCC does not support nullptr")
+#pragma message("Redefine nullptr as NULL")
+#define nullptr NULL
+#endif
+

--- a/src/ssl/sslserver.h
+++ b/src/ssl/sslserver.h
@@ -1,6 +1,8 @@
 #ifndef SSLSERVER_H
 #define SSLSERVER_H
 
+#include "nullptrCheck.h"
+
 #include <QTcpServer>
 #include <QSslSocket>
 #include <QSslKey>


### PR DESCRIPTION
On `CentOS6` and old O.S. the g++ does not support `nullptr`
As we are in the process to migrate to newer OS we still need a way to build on such legacy platforms
Implemented a fix to check the `nullptr` support for GCC, if missing `nullptr` is redefined as `NULL`